### PR TITLE
skip disabled answers to questions when returning responses

### DIFF
--- a/actions/questions.go
+++ b/actions/questions.go
@@ -147,6 +147,10 @@ func QuestionsGetResponses(c buffalo.Context) error {
 	counts := map[string]int{}
 	answers := map[string]string{}
 	for _, a := range question.Answers {
+		if !a.Enabled {
+			continue
+		}
+
 		id := a.ID.String()
 		rq := []models.ResponseAnswer{}
 		count, err := tx.Where("answer_id = (?)", id).Count(&rq)

--- a/actions/responses.go
+++ b/actions/responses.go
@@ -1,8 +1,6 @@
 package actions
 
 import (
-	"log"
-
 	"github.com/YaleSpinup/tweaser/helpers"
 	"github.com/YaleSpinup/tweaser/models"
 	"github.com/gobuffalo/buffalo"
@@ -95,26 +93,9 @@ func ResponsesCreate(c buffalo.Context) error {
 		return errors.WithStack(err)
 	}
 
-	for _, a := range response.Answers {
-		ra := &models.ResponseAnswer{
-			ResponseID: response.ID,
-			AnswerID:   a.ID,
-			QuestionID: response.QuestionID,
-		}
-
-		// Validate the posted data and save it to the database
-		ve, err := tx.ValidateAndCreate(ra)
-		if err != nil {
-			return errors.WithStack(err)
-		}
-		verrs.Append(ve)
-	}
-
 	if verrs.HasAny() {
 		return c.Render(422, r.JSON(verrs))
 	}
-
-	log.Println("done with update")
 
 	return c.Render(202, r.JSON("submitted"))
 }


### PR DESCRIPTION
When returning the responses to a question, it doesn't make sense to show disabled responses, especially since these are used for drawing charts in the UI.  This is especially necessary because you cannot currently delete answers when configuring a question (only disable them).  Maybe we should fix that later.